### PR TITLE
Update 14 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.SecureClient.nuspec
+++ b/MakoIoT.Device.SecureClient.nuspec
@@ -17,19 +17,19 @@
     <description>HttpClient provider for HTTPS, loads certificates from files (MAKO-IoT)</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot secure httpclient https</tags>
     <dependencies>
-		<dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.76.43929" />
-		<dependency id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" />
-		<dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
-		<dependency id="nanoFramework.DependencyInjection" version="1.1.11" />
-		<dependency id="nanoFramework.Runtime.Events" version="1.11.18" />
-		<dependency id="nanoFramework.System.Collections" version="1.5.45" />
-		<dependency id="nanoFramework.System.IO.FileSystem" version="1.1.54" />
-		<dependency id="nanoFramework.System.IO.Streams" version="1.1.59" />
-		<dependency id="nanoFramework.System.Net" version="1.11.1" />
-		<dependency id="nanoFramework.System.Net.Http" version="1.5.150" />
-		<dependency id="nanoFramework.System.Runtime" version="1.0.27" />
-		<dependency id="nanoFramework.System.Text" version="1.2.54" />
-		<dependency id="nanoFramework.System.Threading" version="1.1.32" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.1.4387" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.25" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.29" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.59" />
+      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.78" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.86" />
+      <dependency id="nanoFramework.System.Net" version="1.11.27" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.175" />
+      <dependency id="nanoFramework.System.Runtime" version="1.0.28" />
+      <dependency id="nanoFramework.System.Text" version="1.3.16" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.46" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
+++ b/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -26,44 +27,44 @@
     <Compile Include="Services\IClientProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="MakoIoT.Device.Services.FileStorage">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.76.43929\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.1.4387\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Interface">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.47.44904\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.48.22567\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.11\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.29\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.45\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.59\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Runtime">
-      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.27\lib\nanoFramework.System.Runtime.dll</HintPath>
+    <Reference Include="nanoFramework.System.Runtime, Version=1.0.28.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.28\lib\nanoFramework.System.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.16.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.FileSystem">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.54\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.78.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.78\lib\System.IO.FileSystem.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.86.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.86\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.1\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.27\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.150\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.175.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.175\lib\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.46.1709, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.46\lib\System.Threading.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -80,7 +81,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props'))" />
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets')" />
 </Project>

--- a/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
+++ b/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
@@ -80,7 +80,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props'))" />
     <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props'))" />
     <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets'))" />
   </Target>

--- a/src/MakoIoT.Device.SecureClient/packages.config
+++ b/src/MakoIoT.Device.SecureClient/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.76.43929" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.45" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.54" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.1" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.150" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Runtime" version="1.0.27" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="Nerdbank.GitVersioning" version="3.6.146" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.1.4387" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.78" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.86" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.27" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.175" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Runtime" version="1.0.28" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.46" targetFramework="netnano1.0" />
+  <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.FileStorage from 1.0.76.43929 to 1.1.1.4387</br>Bumps MakoIoT.Device.Services.Interface from 1.0.47.44904 to 1.0.48.22567</br>Bumps nanoFramework.CoreLibrary from 1.15.5 to 1.16.11</br>Bumps nanoFramework.DependencyInjection from 1.1.11 to 1.1.25</br>Bumps nanoFramework.Runtime.Events from 1.11.18 to 1.11.29</br>Bumps nanoFramework.System.Collections from 1.5.45 to 1.5.59</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.54 to 1.1.78</br>Bumps nanoFramework.System.IO.Streams from 1.1.59 to 1.1.86</br>Bumps nanoFramework.System.Net from 1.11.1 to 1.11.27</br>Bumps nanoFramework.System.Net.Http from 1.5.150 to 1.5.175</br>Bumps nanoFramework.System.Runtime from 1.0.27 to 1.0.28</br>Bumps nanoFramework.System.Text from 1.2.54 to 1.3.16</br>Bumps nanoFramework.System.Threading from 1.1.32 to 1.1.46</br>Bumps Nerdbank.GitVersioning from 3.6.146 to 3.7.115</br>
[version update]

### :warning: This is an automated update. :warning:
