### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.SecureClient.nuspec
+++ b/MakoIoT.Device.SecureClient.nuspec
@@ -17,7 +17,7 @@
     <description>HttpClient provider for HTTPS, loads certificates from files (MAKO-IoT)</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot secure httpclient https</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.10.20822" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.11.41578" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />

--- a/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
+++ b/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.10.20822\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.11.41578\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>

--- a/src/MakoIoT.Device.SecureClient/packages.config
+++ b/src/MakoIoT.Device.SecureClient/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.10.20822" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.11.41578" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.FileStorage from 1.1.10.20822 to 1.1.11.41578</br>
[version update]

### :warning: This is an automated update. :warning:
