### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.SecureClient.nuspec
+++ b/MakoIoT.Device.SecureClient.nuspec
@@ -17,16 +17,16 @@
     <description>HttpClient provider for HTTPS, loads certificates from files (MAKO-IoT)</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot secure httpclient https</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.15.13530" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.16.45841" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
       <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.85" />
+      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.87" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
       <dependency id="nanoFramework.System.Net" version="1.11.43" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.193" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.195" />
       <dependency id="nanoFramework.System.Runtime" version="1.0.28" />
       <dependency id="nanoFramework.System.Text" version="1.3.42" />
       <dependency id="nanoFramework.System.Threading" version="1.1.52" />

--- a/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
+++ b/src/MakoIoT.Device.SecureClient/MakoIoT.Device.SecureClient.nfproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.15.13530\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.16.45841\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.55.11594\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
@@ -51,8 +51,8 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.85.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.85\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.87.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.87\lib\System.IO.FileSystem.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.96.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>
@@ -60,8 +60,8 @@
     <Reference Include="System.Net, Version=1.11.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Net.1.11.43\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.193.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.193\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.195.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.195\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.SecureClient/packages.config
+++ b/src/MakoIoT.Device.SecureClient/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.15.13530" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.16.45841" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.85" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.87" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.43" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.193" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.195" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.28" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.FileStorage from 1.1.15.13530 to 1.1.16.45841</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.85 to 1.1.87</br>Bumps nanoFramework.System.Net.Http from 1.5.193 to 1.5.195</br>
[version update]

### :warning: This is an automated update. :warning:
